### PR TITLE
Log wav file metadata errors

### DIFF
--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFile.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFile.kt
@@ -8,6 +8,7 @@ import java.io.IOException
 import java.lang.Exception
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import org.slf4j.LoggerFactory
 
 private const val RIFF = "RIFF"
 private const val WAVE = "WAVE"
@@ -33,6 +34,8 @@ class InvalidWavFileException(message: String? = null) : Exception(message)
  * Wraps a file for the purposes of reading wav header metadata
  */
 class WavFile private constructor() {
+
+    val logger = LoggerFactory.getLogger(WavFile::class.java)
 
     internal lateinit var file: File
         private set
@@ -184,7 +187,12 @@ class WavFile private constructor() {
                 it.skip(metadataStart.toLong())
                 it.read(bytes)
             }
-            metadata.parseMetadata(ByteBuffer.wrap(bytes))
+            try {
+                metadata.parseMetadata(ByteBuffer.wrap(bytes))
+            } catch (e: Exception) {
+                logger.error("Error parsing metadata for file: ${file.name}")
+                throw e
+            }
         }
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/Main.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/Main.kt
@@ -1,8 +1,15 @@
 package org.wycliffeassociates.otter.jvm.workbookapp
 
+import org.wycliffeassociates.otter.jvm.workbookapp.di.DaggerAppDependencyGraph
+import org.wycliffeassociates.otter.jvm.workbookapp.logging.ConfigureLogger
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.OtterApp
 import tornadofx.launch
 
 fun main(args: Array<String>) {
+    val dependencyGraph = DaggerAppDependencyGraph.builder().build()
+    val dp = dependencyGraph.injectDirectoryProvider()
+    ConfigureLogger(
+        dp.logsDirectory
+    ).configure()
     launch<OtterApp>(args)
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/Main.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/Main.kt
@@ -1,15 +1,17 @@
 package org.wycliffeassociates.otter.jvm.workbookapp
 
-import org.wycliffeassociates.otter.jvm.workbookapp.di.DaggerAppDependencyGraph
+import org.wycliffeassociates.otter.common.OratureInfo
 import org.wycliffeassociates.otter.jvm.workbookapp.logging.ConfigureLogger
+import org.wycliffeassociates.otter.jvm.workbookapp.persistence.DirectoryProvider
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.OtterApp
 import tornadofx.launch
 
 fun main(args: Array<String>) {
-    val dependencyGraph = DaggerAppDependencyGraph.builder().build()
-    val dp = dependencyGraph.injectDirectoryProvider()
-    ConfigureLogger(
-        dp.logsDirectory
-    ).configure()
+    initLogger()
     launch<OtterApp>(args)
+}
+
+fun initLogger() {
+    val dirProv = DirectoryProvider(OratureInfo.SUITE_NAME)
+    ConfigureLogger(dirProv.logsDirectory).configure()
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/OtterApp.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/OtterApp.kt
@@ -23,8 +23,7 @@ class OtterApp : App(RootView::class), IDependencyGraphProvider {
     init {
         val directoryProvider = dependencyGraph.injectDirectoryProvider()
         Thread.setDefaultUncaughtExceptionHandler(OtterExceptionHandler(directoryProvider))
-        //initializeLogger(directoryProvider)
-
+        initializeLogger(directoryProvider)
         importStylesheet<AppStyles>()
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/OtterApp.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/OtterApp.kt
@@ -16,7 +16,6 @@ import tornadofx.*
 import tornadofx.FX.Companion.messages
 
 class OtterApp : App(RootView::class), IDependencyGraphProvider {
-
     override val dependencyGraph = DaggerAppDependencyGraph.builder().build()
     var shouldBlockWindowCloseRequest = false
 
@@ -31,8 +30,6 @@ class OtterApp : App(RootView::class), IDependencyGraphProvider {
         ConfigureLogger(
             directoryProvider.logsDirectory
         ).configure()
-        val logger = LoggerFactory.getLogger(OtterApp::class.java)
-        logger.info("Initialized logger")
     }
 
     override fun start(stage: Stage) {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/OtterApp.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/OtterApp.kt
@@ -3,7 +3,6 @@ package org.wycliffeassociates.otter.jvm.workbookapp.ui
 import javafx.scene.layout.Pane
 import javafx.stage.Stage
 import javafx.stage.StageStyle
-import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
 import org.wycliffeassociates.otter.jvm.workbookapp.SnackbarHandler
 import org.wycliffeassociates.otter.jvm.workbookapp.di.DaggerAppDependencyGraph

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/OtterApp.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/OtterApp.kt
@@ -3,6 +3,7 @@ package org.wycliffeassociates.otter.jvm.workbookapp.ui
 import javafx.scene.layout.Pane
 import javafx.stage.Stage
 import javafx.stage.StageStyle
+import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
 import org.wycliffeassociates.otter.jvm.workbookapp.SnackbarHandler
 import org.wycliffeassociates.otter.jvm.workbookapp.di.DaggerAppDependencyGraph
@@ -15,13 +16,15 @@ import tornadofx.*
 import tornadofx.FX.Companion.messages
 
 class OtterApp : App(RootView::class), IDependencyGraphProvider {
+
     override val dependencyGraph = DaggerAppDependencyGraph.builder().build()
     var shouldBlockWindowCloseRequest = false
 
     init {
         val directoryProvider = dependencyGraph.injectDirectoryProvider()
         Thread.setDefaultUncaughtExceptionHandler(OtterExceptionHandler(directoryProvider))
-        initializeLogger(directoryProvider)
+        //initializeLogger(directoryProvider)
+
         importStylesheet<AppStyles>()
     }
 
@@ -29,6 +32,8 @@ class OtterApp : App(RootView::class), IDependencyGraphProvider {
         ConfigureLogger(
             directoryProvider.logsDirectory
         ).configure()
+        val logger = LoggerFactory.getLogger(OtterApp::class.java)
+        logger.info("Initialized logger")
     }
 
     override fun start(stage: Stage) {


### PR DESCRIPTION
Fixes logger configuration

Logs files that throw exceptions when parsing wav chunks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/282)
<!-- Reviewable:end -->
