### PR TITLE
isNotEmpty to isNotBlank

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/database/AppDatabase.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/database/AppDatabase.kt
@@ -53,7 +53,7 @@ class AppDatabase(
             .bufferedReader()
             .readText()
             .split(";")
-            .filter { it.isNotEmpty() }
+            .filter { it.isNotBlank() }
             .map { "$it;" }
 
         // Execute each SQL statement


### PR DESCRIPTION
If the last line of the sql file is an empty line, the next block of code will try to execute a newline as a sql command, causing an exception to be thrown- this will only affect startup of a clean install; subsequent installs will avoid this function making the issue difficult to track down.

isNotBlank will filter out purely whitespace lines in addition to empty lists, fixing the issue.