### PR TITLE
Improve adding plugins for Mac (#298)

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/dialogs/AddPluginDialog.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/dialogs/AddPluginDialog.kt
@@ -54,7 +54,7 @@ class AddPluginDialog : OtterDialog() {
                 textfield {
                     addClass("txt-input")
                     hgrow = Priority.ALWAYS
-                    textProperty().bind(viewModel.pathProperty)
+                    textProperty().bindBidirectional(viewModel.pathProperty)
                 }
                 button(messages["browse"]) {
                     addClass("btn", "btn--secondary")
@@ -66,7 +66,8 @@ class AddPluginDialog : OtterDialog() {
                             mode = FileChooserMode.Single
                         )
                         if (files.isNotEmpty()) {
-                            viewModel.pathProperty.set(files.single().toString())
+                            val finalPath = viewModel.completePluginPath(files.single().toString())
+                            viewModel.pathProperty.set(finalPath)
                         }
                     }
                 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/AddPluginViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/AddPluginViewModel.kt
@@ -1,5 +1,6 @@
 package org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel
 
+import java.io.File
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleStringProperty
 import org.slf4j.LoggerFactory
@@ -69,5 +70,21 @@ class AddPluginViewModel : ViewModel() {
             }
             .onErrorComplete()
             .subscribe()
+    }
+
+    /**
+     * Allows for completing the path to the plugin binary, if needed based on platform.
+     * Currently only adds the remaining path after the .app directory on MacOS.
+     */
+    fun completePluginPath(path: String): String {
+        if (File(path).isDirectory && path.matches(Regex(".*.app"))) {
+            val macPath = File(path, "Contents/MacOS/")
+            if (macPath.exists()) {
+                // This directory may have multiple files, but we can't necessarily know the binary name
+                // thus, we'll try the first, and if it's wrong, the user can edit the text after.
+                return macPath.listFiles().first().absolutePath
+            }
+        }
+        return path
     }
 }


### PR DESCRIPTION
On MacOS, application binaries are deeper within their .app bundle in the /Applications or /System/Applications directories. These directories are treated as files in the JavaFX FileChooser, and as such cannot be used to select the binary.

We add the ability to edit the text in the path field, rather than rely solely on the result of the FileChooser.

Additionally, we further process the path before setting the value, detect if it is MacOS, and automatically navigate for the user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/299)
<!-- Reviewable:end -->
