### PR TITLE
Fix Marker App Seeking

### DIFF
--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/viewmodel/VerseMarkerViewModel.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/viewmodel/VerseMarkerViewModel.kt
@@ -99,11 +99,17 @@ class VerseMarkerViewModel : ViewModel() {
     }
 
     fun seekNext() {
+        val wasPlaying = audioPlayer.isPlaying()
+        if (wasPlaying) { audioController?.toggle() }
         seek(markers.seekNext(audioPlayer.getAbsoluteLocationInFrames()))
+        if (wasPlaying) { audioController?.toggle() }
     }
 
     fun seekPrevious() {
+        val wasPlaying = audioPlayer.isPlaying()
+        if (wasPlaying) { audioController?.toggle() }
         seek(markers.seekPrevious(audioPlayer.getAbsoluteLocationInFrames()))
+        if (wasPlaying) { audioController?.toggle() }
     }
 
     fun writeMarkers(): Completable {


### PR DESCRIPTION
Seek previous algorithm changed/simplified to fix a bug with seek returning to the beginning of the file if seeking to a previous marker while playing audio.

Pauses/resumes before seeking forward or back to prevent playback interfering with position changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/300)
<!-- Reviewable:end -->
