### PR TITLE
Fixed translation/book wizard bugs

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/WorkbookRepository.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/WorkbookRepository.kt
@@ -80,7 +80,9 @@ class WorkbookRepository(private val db: IDatabaseAccessors) : IWorkbookReposito
     override fun getProjects(): Single<List<Workbook>> {
         return db.getDerivedProjects()
             .map { projects ->
-                projects.filter { it.resourceContainer?.type == ContainerType.Book }
+                projects.filter {
+                    it.resourceContainer?.type == ContainerType.Book
+                }
             }
             .flattenAsObservable { it }
             .flatMapMaybe(::getWorkbook)
@@ -93,6 +95,10 @@ class WorkbookRepository(private val db: IDatabaseAccessors) : IWorkbookReposito
                 projects
                     .filter { it.resourceContainer?.type == ContainerType.Book }
                     .filter { it.resourceContainer?.language == translation.target }
+                    .filter {
+                        val sourceProject = db.getSourceProject(it).blockingGet()
+                        sourceProject.resourceContainer?.language == translation.source
+                    }
             }
             .flattenAsObservable { it }
             .flatMapMaybe(::getWorkbook)

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/card/BookCardCell.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/card/BookCardCell.kt
@@ -62,7 +62,8 @@ class BookCardCell : HBox() {
     }
 
     private fun backgroundImage(file: File): BackgroundImage {
-        val image = Image(file.inputStream())
+        val url = file.toURI().toURL().toExternalForm()
+        val image = Image(url, true)
         val backgroundSize = BackgroundSize(
             BackgroundSize.AUTO,
             BackgroundSize.AUTO,

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/BookCell.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/BookCell.kt
@@ -5,6 +5,7 @@ import javafx.beans.property.SimpleObjectProperty
 import javafx.collections.ObservableList
 import javafx.scene.control.ListCell
 import org.wycliffeassociates.otter.common.data.primitives.Collection
+import org.wycliffeassociates.otter.common.data.workbook.Workbook
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.CoverArtAccessor
 import org.wycliffeassociates.otter.jvm.controls.card.BookCardCell
 import org.wycliffeassociates.otter.jvm.workbookapp.enums.ProjectType
@@ -13,7 +14,7 @@ import java.util.concurrent.Callable
 
 class BookCell(
     private val projectTypeProperty: SimpleObjectProperty<ProjectType>,
-    private val existingBooks: ObservableList<Collection> = observableListOf(),
+    private val existingBooks: ObservableList<Workbook> = observableListOf(),
     private val onSelected: (Collection) -> Unit
 ) : ListCell<Collection>() {
 
@@ -42,7 +43,9 @@ class BookCell(
 
             disableProperty().bind(Bindings.createBooleanBinding(
                 Callable {
-                    existingBooks.map { it.slug }.contains(item.slug)
+                    existingBooks.map {
+                        it.target.slug
+                    }.contains(item.slug)
                 },
                 existingBooks
             ))

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/HomePage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/HomePage.kt
@@ -9,7 +9,6 @@ import org.wycliffeassociates.otter.jvm.controls.card.BookCard
 import org.wycliffeassociates.otter.jvm.controls.card.NewTranslationCard
 import org.wycliffeassociates.otter.jvm.controls.card.TranslationCard
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.NavigationMediator
-import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.BookWizardViewModel
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.HomePageViewModel
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.WorkbookDataStore
 import tornadofx.*
@@ -96,10 +95,7 @@ class HomePage : Fragment() {
                             seeLessTextProperty.set(messages["seeLess"])
 
                             setOnNewBookAction {
-                                val vm: BookWizardViewModel = find()
-                                vm.sourceLanguageProperty.set(it.sourceLanguage)
-                                vm.targetLanguageProperty.set(it.targetLanguage)
-                                viewModel.createProject()
+                                viewModel.createProject(it)
                             }
                         }
                     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/book/BookSelection.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/book/BookSelection.kt
@@ -39,7 +39,11 @@ class BookSelection : Fragment() {
                     label {
                         addClass("book-wizard__language")
                         graphic = FontIcon(Material.HEARING)
-                        textProperty().bind(viewModel.sourceLanguageProperty.stringBinding { it?.name })
+                        textProperty().bind(
+                            viewModel.translationProperty.stringBinding {
+                                it?.sourceLanguage?.name
+                            }
+                        )
                     }
                     label {
                         addClass("book-wizard__divider")
@@ -48,7 +52,11 @@ class BookSelection : Fragment() {
                     label {
                         addClass("book-wizard__language")
                         graphic = FontIcon(MaterialDesign.MDI_VOICE)
-                        textProperty().bind(viewModel.targetLanguageProperty.stringBinding { it?.name })
+                        textProperty().bind(
+                            viewModel.translationProperty.stringBinding {
+                                it?.targetLanguage?.name
+                            }
+                        )
                     }
                 }
             }
@@ -111,6 +119,7 @@ class BookSelection : Fragment() {
     override fun onDock() {
         navigator.dock(this, breadCrumb)
         viewModel.reset()
+        viewModel.loadExistingProjects()
         viewModel.loadResources()
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/book/ProjectTypeSelection.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/book/ProjectTypeSelection.kt
@@ -46,7 +46,11 @@ class ProjectTypeSelection : Fragment() {
                     label {
                         addClass("book-wizard__language")
                         graphic = FontIcon(Material.HEARING)
-                        textProperty().bind(viewModel.sourceLanguageProperty.stringBinding { it?.name })
+                        textProperty().bind(
+                            viewModel.translationProperty.stringBinding {
+                                it?.sourceLanguage?.name
+                            }
+                        )
                     }
                     label {
                         addClass("book-wizard__divider")
@@ -55,7 +59,11 @@ class ProjectTypeSelection : Fragment() {
                     label {
                         addClass("book-wizard__language")
                         graphic = FontIcon(MaterialDesign.MDI_VOICE)
-                        textProperty().bind(viewModel.targetLanguageProperty.stringBinding { it?.name })
+                        textProperty().bind(
+                            viewModel.translationProperty.stringBinding {
+                                it?.targetLanguage?.name
+                            }
+                        )
                     }
                 }
             }
@@ -114,7 +122,7 @@ class ProjectTypeSelection : Fragment() {
     }
 
     init {
-        importStylesheet(javaClass.getResource("/css/book-wizard.css").toExternalForm())
+        importStylesheet(resources.get("/css/book-wizard.css"))
     }
 
     override fun onDock() {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/SourceLanguageSelection.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/SourceLanguageSelection.kt
@@ -64,16 +64,15 @@ class SourceLanguageSelection : Fragment() {
     }
 
     init {
-        importStylesheet(javaClass.getResource("/css/translation-wizard.css").toExternalForm())
-        importStylesheet(javaClass.getResource("/css/language-card-cell.css").toExternalForm())
-        importStylesheet(javaClass.getResource("/css/filtered-search-bar.css").toExternalForm())
+        importStylesheet(resources.get("/css/translation-wizard.css"))
+        importStylesheet(resources.get("/css/language-card-cell.css"))
+        importStylesheet(resources.get("/css/filtered-search-bar.css"))
 
         translationViewModel.sourceLanguages.onChange {
             viewModel.regions.setAll(
                 it.list
                     .distinctBy { language -> language.region }
                     .map { language -> language.region }
-                    .filter { region -> region.isNotBlank() }
             )
             viewModel.setFilterMenu()
         }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/TargetLanguageSelection.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/TargetLanguageSelection.kt
@@ -72,7 +72,6 @@ class TargetLanguageSelection : Fragment() {
                 it.list
                     .distinctBy { language -> language.region }
                     .map { language -> language.region }
-                    .filter { region -> region.isNotBlank() }
             )
             viewModel.setFilterMenu()
         }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/HomePageViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/HomePageViewModel.kt
@@ -80,7 +80,9 @@ class HomePageViewModel : ViewModel() {
         workbookDataStore.activeWorkbookProperty.set(null)
     }
 
-    fun createProject() {
+    fun createProject(translation: TranslationCardModel) {
+        val vm: BookWizardViewModel = find()
+        vm.translationProperty.set(translation)
         navigator.dock<BookSelection>()
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/LanguageSelectionViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/LanguageSelectionViewModel.kt
@@ -41,9 +41,9 @@ class LanguageSelectionViewModel(items: ObservableList<Language>) : ViewModel() 
                 Predicate { true }
             } else {
                 Predicate { language ->
-                    language.slug.startsWith(query, true)
-                        .or(language.name.startsWith(query, true))
-                        .or(language.anglicizedName.startsWith(query, true))
+                    language.slug.contains(query, true)
+                        .or(language.name.contains(query, true))
+                        .or(language.anglicizedName.contains(query, true))
                 }
             }
             filteredLanguages.predicate = queryPredicate.and(regionPredicate)
@@ -64,7 +64,8 @@ class LanguageSelectionViewModel(items: ObservableList<Language>) : ViewModel() 
         items.add(createMenuSeparator(messages["region"]))
         items.addAll(
             regions.map {
-                createMenuItem(it, true) { selected ->
+                val title = it.ifBlank { messages["unknown"] }
+                createMenuItem(title, true) { selected ->
                     when (selected) {
                         true -> selectedRegions.add(it)
                         else -> selectedRegions.remove(it)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModel.kt
@@ -117,6 +117,11 @@ class TranslationViewModel : ViewModel() {
     private fun loadTranslations() {
         languageRepo
             .getAllTranslations()
+            .map { list ->
+                list.filter {
+                    it.source == selectedSourceLanguageProperty.value
+                }
+            }
             .observeOnFx()
             .doOnError { e ->
                 logger.error("Error loading translations", e)

--- a/jvm/workbookapp/src/main/resources/Messages_en.properties
+++ b/jvm/workbookapp/src/main/resources/Messages_en.properties
@@ -199,3 +199,4 @@ newTestament = New Testament
 newTranslation = New Translation
 resume = Resume
 goHome = Go Home
+unknown = Unknown


### PR DESCRIPTION
1. Fixed a bug when recently selected book name and image shows up in the dialog, when deleting another book. Done by removing change listeners onDock callback
2. Fixed a bug when you could't create a translation project with a target language that was selected in another translation project
3. Allowing searching books and languages by a string that a book/language name contains in the wizards
4. Book images load optimization (lazy load)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/305)
<!-- Reviewable:end -->
