### PR TITLE
Remove scroll bar styling

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/theme/AppStyles.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/theme/AppStyles.kt
@@ -60,22 +60,6 @@ class AppStyles : Stylesheet() {
             fontWeight = FontWeight.BOLD
             cursor = Cursor.HAND
         }
-        // Material design scroll bar
-        scrollBar {
-            backgroundColor += Color.TRANSPARENT
-            padding = box(0.px, 4.px)
-            prefWidth = 16.px
-            Stylesheet.thumb {
-                backgroundColor += Color.DARKGRAY
-                backgroundRadius += box(10.px)
-            }
-            Stylesheet.incrementArrow {
-                visibility = FXVisibility.COLLAPSE
-            }
-            Stylesheet.decrementArrow {
-                visibility = FXVisibility.COLLAPSE
-            }
-        }
 
         scrollPane {
             backgroundColor += Color.TRANSPARENT


### PR DESCRIPTION
Resets back to the default scroll bar styling which is a little more easily understood

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/309)
<!-- Reviewable:end -->
