### PR TITLE
Moves the scrollbar next to the listview

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/WorkbookPage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/WorkbookPage.kt
@@ -311,8 +311,8 @@ class WorkbookPage : Fragment() {
             return VBox().apply {
                 hgrow = Priority.ALWAYS
                 vgrow = Priority.ALWAYS
-                alignment = Pos.CENTER
-                addClass(AppStyles.whiteBackground)
+                alignment = Pos.CENTER_LEFT
+                addClass("workbook-page")
                 progressindicator {
                     visibleProperty().bind(viewModel.loadingProperty)
                     managedProperty().bind(visibleProperty())

--- a/jvm/workbookapp/src/main/resources/css/home-page.css
+++ b/jvm/workbookapp/src/main/resources/css/home-page.css
@@ -2,4 +2,5 @@
     -fx-padding: 40px;
     -fx-pref-width: 800px;
     -fx-spacing: 20px;
+    -fx-max-width: 800px;
 }

--- a/jvm/workbookapp/src/main/resources/css/workbook-page.css
+++ b/jvm/workbookapp/src/main/resources/css/workbook-page.css
@@ -1,6 +1,11 @@
+.workbook-page {
+    -fx-background-color: #f7faff;
+}
+
 .workbook-page__chapter-list {
     -fx-padding: 20px 0 0 30px;
     -fx-background-color: #f7faff;
+    -fx-max-width: 800px;
 }
 
 .workbook-page__chapter-list .list-cell:selected,


### PR DESCRIPTION
Let's confirm with Thomas that this is desired, it looks alright on this page, but if the same approach is done on the home page, it's a little visually jarring. So we might want to hold off on this, because it might be preferred to just stick with consistency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/310)
<!-- Reviewable:end -->
