### PR TITLE
Bugfix; min switched to max

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/usfm/UsfmProjectReader.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/usfm/UsfmProjectReader.kt
@@ -137,7 +137,7 @@ private fun parseUSFMToChapterTrees(reader: Reader, projectSlug: String): List<O
     val chapters = doc.getChildMarkers(CMarker::class.java)
     return chapters.map { chapter ->
         val verses = chapter.getChildMarkers(VMarker::class.java)
-        val startVerse = verses.maxByOrNull { it.startingVerse }?.startingVerse ?: 1
+        val startVerse = verses.minByOrNull { it.startingVerse }?.startingVerse ?: 1
         val endVerse = verses.maxByOrNull { it.endingVerse }?.endingVerse ?: 1
         val chapterSlug = "${projectSlug}_${chapter.number}"
         val chapterCollection = Collection(


### PR DESCRIPTION
minBy was deprecated, updating kotlin required switching to the function minByOrNull. This was accidentally changed to maxByOrNull in PR 302, commit 77c7dcc7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/320)
<!-- Reviewable:end -->
