### PR TITLE
Clamp bounds when opening wav file

### DIFF
--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunk.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunk.kt
@@ -182,6 +182,11 @@ internal class CueChunk : RiffChunk {
             val subchunkLabel = chunk.getText(CHUNK_LABEL_SIZE)
             val subchunkSize = chunk.int
 
+
+            if (subchunkSize < 0) {
+                throw InvalidWavFileException("Chunk $subchunkLabel has a negative size of $subchunkSize")
+            }
+
             if (chunk.remaining() < subchunkSize) {
                 throw InvalidWavFileException(
                     """Chunk $subchunkLabel is of size: $subchunkSize 
@@ -230,12 +235,13 @@ internal class CueChunk : RiffChunk {
         if (!chunk.hasRemaining()) {
             return
         }
+
         // read number of cues
         val numCues = chunk.int
 
         // each cue subchunk should be 24 bytes, plus 4 for the number of cues field
         if (chunk.remaining() != CUE_DATA_SIZE * numCues) {
-            throw InvalidWavFileException()
+            throw InvalidWavFileException("Cue Chunk Subchunk size is not correct")
         }
 
         // For each cue, read the cue Id and the cue location

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFile.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFile.kt
@@ -206,19 +206,19 @@ internal class WavFile private constructor() : AudioFormatStrategy {
     }
 
     private fun parseMetadata() {
-        if (totalDataLength > totalAudioLength + (WAV_HEADER_SIZE - CHUNK_HEADER_SIZE)) {
-            val metadataSize = totalDataLength - totalAudioLength - (WAV_HEADER_SIZE - CHUNK_HEADER_SIZE)
-            val bytes = ByteArray(metadataSize)
-            file.inputStream().use {
-                val metadataStart = WAV_HEADER_SIZE + totalAudioLength
-                it.skip(metadataStart.toLong())
-                it.read(bytes)
-            }
+        val nonMetadataSize = totalAudioLength + (WAV_HEADER_SIZE - CHUNK_HEADER_SIZE)
+        if (totalDataLength > nonMetadataSize) {
             try {
+                val metadataSize = totalDataLength - nonMetadataSize
+                val bytes = ByteArray(metadataSize)
+                file.inputStream().use {
+                    val metadataStart = WAV_HEADER_SIZE + totalAudioLength
+                    it.skip(metadataStart.toLong())
+                    it.read(bytes)
+                }
                 metadata.parseMetadata(ByteBuffer.wrap(bytes))
             } catch (e: Exception) {
                 logger.error("Error parsing metadata for file: ${file.name}")
-                throw e
             }
         }
     }

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFileReader.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFileReader.kt
@@ -73,9 +73,9 @@ internal class WavFileReader(val wav: WavFile, val start: Int? = null, val end: 
         end *= wav.frameSizeInBytes
         end += WAV_HEADER_SIZE
 
-        // Should be clamped between header size, computed beginning, and the file length minus the header size
-        val clampedBegin = max(WAV_HEADER_SIZE, min(begin, max(wav.file.length().toInt() - WAV_HEADER_SIZE, WAV_HEADER_SIZE)))
-        val clampedEnd = max(clampedBegin, min(end, max(wav.file.length().toInt() - WAV_HEADER_SIZE, WAV_HEADER_SIZE)))
+        // Should be clamped between header size, computed beginning, and the file length
+        val clampedBegin = max(WAV_HEADER_SIZE, min(begin, max(wav.file.length().toInt(), WAV_HEADER_SIZE)))
+        val clampedEnd = max(clampedBegin, min(end, max(wav.file.length().toInt(), WAV_HEADER_SIZE)))
 
         if (clampedBegin != begin || clampedEnd != end) {
             logger.error("Error in file ${wav.file.name}")

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavMetadata.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavMetadata.kt
@@ -20,10 +20,13 @@ package org.wycliffeassociates.otter.common.audio.wav
 
 import java.io.OutputStream
 import java.nio.ByteBuffer
+import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.audio.AudioMetadata
 import org.wycliffeassociates.otter.common.audio.AudioCue
 
-internal class WavMetadata(parsableChunks: List<RiffChunk>? = null): AudioMetadata {
+internal class WavMetadata(parsableChunks: List<RiffChunk>? = null) : AudioMetadata {
+
+    private val logger = LoggerFactory.getLogger(WavMetadata::class.java)
 
     private val cueChunk: CueChunk
     private val chunks: Set<RiffChunk>


### PR DESCRIPTION
Clamps the bounds when opening a wav file so that it does not try to map beyond the actual limits of the file.

This can happen if the audio data length in the wav header is wrong, which could be larger than the file itself.

Also logs the issue, as it is indicative of wav file corruption.

Addresses the stack trace:
java.io.IOException: Channel not open for writing - cannot extend file to required size
	at java.base/sun.nio.ch.FileChannelImpl.map(FileChannelImpl.java:976)
	at org.wycliffeassociates.otter.common.audio.wav.WavFileReader.open(WavFileReader.kt:39)
	at org.wycliffeassociates.otter.jvm.device.audio.AudioBufferPlayer.load(AudioBufferPlayer.kt:59)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/322)
<!-- Reviewable:end -->
