### PR TITLE
Remove Redundant Audio Players

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordableViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordableViewModel.kt
@@ -305,8 +305,6 @@ open class RecordableViewModel(
             }
             .subscribe { take ->
                 if (takeCardModels.find { it.take.equals(take) } == null) {
-                    val ap: IAudioPlayer = (app as OtterApp).dependencyGraph.injectPlayer()
-                    ap.load(take.file)
                     addToAlternateTakes(
                         take.mapToCardModel(take.equals(selected))
                     )


### PR DESCRIPTION
Injecting an audio player and loading a file is done in the first few lines of take.mapToCardModel, and is thus redundant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/323)
<!-- Reviewable:end -->
