### PR TITLE
Improve images

### DIFF
--- a/assets/build.gradle
+++ b/assets/build.gradle
@@ -16,6 +16,13 @@ repositories {
         }
         metadataSources { artifact() }
     }
+    ivy {
+        url 'https://nightlybuilds.s3.amazonaws.com/Bible-Translation-Tools/artwork/'
+        patternLayout {
+            artifact '[artifact].[ext]'
+        }
+        metadataSources { artifact() }
+    }
 }
 
 configurations {
@@ -25,6 +32,7 @@ configurations {
 dependencies {
     content 'wycliffeassociates:en_ulb:v19-10@zip'
     content 'unfoldingword:langnames@json'
+    content 'bible-translation-tools:bible_artwork@zip'
     implementation "io.reactivex.rxjava2:rxkotlin:$rxkotlinVer"
     implementation project(":common")
 
@@ -41,7 +49,7 @@ task copyToResources(type: Copy) {
             if (filename.matches(".*.json\$")) {
                 filename.replaceAll('-\\.json$', '.json')
             } else {
-                filename.replaceAll('-v\\d{2}-\\d{2}\\.zip$', '.zip')
+                filename.replaceAll('-(v\\d{2}-\\d{2})?\\.zip$', '.zip')
             }
     }
 }

--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeApp.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeApp.kt
@@ -26,6 +26,7 @@ import javax.inject.Inject
 class InitializeApp @Inject constructor(
     private val initializeLanguages: InitializeLanguages,
     private val initializeUlb: InitializeUlb,
+    private val initializeArtwork: InitializeArtwork,
     private val initializeRecorder: InitializeRecorder,
     private val initializeMarker: InitializeMarker,
     private val initializePlugins: InitializePlugins,
@@ -42,6 +43,7 @@ class InitializeApp @Inject constructor(
                 val initializers = listOf(
                     initializeLanguages,
                     initializeUlb,
+                    initializeArtwork,
                     initializeRecorder,
                     initializeMarker,
                     initializePlugins,

--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeArtwork.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeArtwork.kt
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2020, 2021 Wycliffe Associates
+ *
+ * This file is part of Orature.
+ *
+ * Orature is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Orature is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Orature.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.wycliffeassociates.otter.assets.initialization
+
+import io.reactivex.Completable
+import java.io.File
+import org.slf4j.LoggerFactory
+import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportException
+import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportResourceContainer
+import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportResult
+import org.wycliffeassociates.otter.common.persistence.config.Installable
+import org.wycliffeassociates.otter.common.persistence.repositories.IInstalledEntityRepository
+import javax.inject.Inject
+import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
+
+private const val ARTWORK_FILENAME = "bible_artwork.zip"
+private const val ARTWORK_PATH = "content/$ARTWORK_FILENAME"
+
+class InitializeArtwork @Inject constructor(
+    private val installedEntityRepo: IInstalledEntityRepository,
+    private val directoryProvider: IDirectoryProvider
+) : Installable {
+
+    override val name = "ARTWORK"
+    override val version = 1
+
+    private val log = LoggerFactory.getLogger(InitializeArtwork::class.java)
+
+    override fun exec(): Completable {
+        return Completable
+            .fromCallable {
+                val installedVersion = installedEntityRepo.getInstalledVersion(this)
+                if (installedVersion != version) {
+                    log.info("Initializing $name version: $version...")
+                    copyBibleArtworkContainer()
+                } else {
+                    log.info("$name up to date with version: $version")
+                }
+            }
+            .doOnError { e ->
+                log.error("Error in initializeArtwork", e)
+            }
+    }
+
+    private fun copyBibleArtworkContainer() {
+        if (!File(directoryProvider.resourceContainerDirectory, ARTWORK_FILENAME).exists()) {
+            log.info("Copying bible artwork")
+            ClassLoader.getSystemResourceAsStream(ARTWORK_PATH)
+                .transferTo(
+                    File(
+                        directoryProvider.resourceContainerDirectory.absolutePath,
+                        ARTWORK_FILENAME
+                    ).outputStream()
+                )
+        } else {
+            log.info("Artwork not initialized but ${ARTWORK_FILENAME} exists in rc directory")
+        }
+    }
+}

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/primitives/ContainerType.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/primitives/ContainerType.kt
@@ -27,6 +27,7 @@ enum class ContainerType(val slug: String) {
     Bundle("bundle"),
     Book("book"),
     Help("help"),
+    IMAGE("img"),
 
     @Deprecated("Type not supported")
     Dictionary("dict"),

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/artwork/BibleImagesDataSource.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/artwork/BibleImagesDataSource.kt
@@ -27,7 +27,8 @@ import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 
 class BibleImagesDataSource(
-    private val directoryProvider: IDirectoryProvider
+    private val directoryProvider: IDirectoryProvider,
+    private val imagesContainerName: String = "bible_artwork.zip"
 ) : ImagesDataSource {
 
     private val cacheDir = File(
@@ -95,7 +96,6 @@ class BibleImagesDataSource(
     }
 
     companion object {
-        private const val imagesContainerName = "bible_artwork.zip"
         private val filesCache = ConcurrentHashMap<String, File>()
     }
 }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/artwork/BibleImagesDataSource.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/artwork/BibleImagesDataSource.kt
@@ -95,7 +95,7 @@ class BibleImagesDataSource(
     }
 
     companion object {
-        private const val imagesContainerName = "bible_artwork"
+        private const val imagesContainerName = "bible_artwork.zip"
         private val filesCache = ConcurrentHashMap<String, File>()
     }
 }

--- a/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/artwork/TestBibleImagesDataSource.kt
+++ b/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/artwork/TestBibleImagesDataSource.kt
@@ -68,7 +68,7 @@ class TestBibleImagesDataSource {
 
     @Test
     fun testGetBibleImage() {
-        val dataSource = BibleImagesDataSource(directoryProviderMock)
+        val dataSource = BibleImagesDataSource(directoryProviderMock, imagesContainerName)
         val image = dataSource.getImage(metadataMock, project)
 
         assertNotNull(
@@ -81,7 +81,7 @@ class TestBibleImagesDataSource {
     fun testGetBibleImageWithRatio() {
         val ratio4x3 = ImageRatio.FOUR_BY_THREE
         val ratioString = ratio4x3.toString()
-        val dataSource = BibleImagesDataSource(directoryProviderMock)
+        val dataSource = BibleImagesDataSource(directoryProviderMock, imagesContainerName)
         val image = dataSource.getImage(metadataMock, project, ratio4x3)
 
         assertNotNull(
@@ -100,7 +100,7 @@ class TestBibleImagesDataSource {
         val nonBibleProject = "unknown"
         val remoteContentProject = "tit"
 
-        val dataSource = BibleImagesDataSource(directoryProviderMock)
+        val dataSource = BibleImagesDataSource(directoryProviderMock, imagesContainerName)
         val notFoundImage = dataSource.getImage(metadataMock, genSlug)
         val nonBibleNotFoundImage =  dataSource.getImage(metadataMock, nonBibleProject)
         val remoteImageNotFound =  dataSource.getImage(metadataMock, remoteContentProject)
@@ -123,7 +123,7 @@ class TestBibleImagesDataSource {
     fun `test fallback to default when aspect ratio not found`() {
         val ratio16x9 = ImageRatio.SIXTEEN_BY_NINE
         val ratioString = ratio16x9.toString()
-        val dataSource = BibleImagesDataSource(directoryProviderMock)
+        val dataSource = BibleImagesDataSource(directoryProviderMock, imagesContainerName)
         val image = dataSource.getImage(metadataMock, project, ratio16x9)
 
         assertNotNull(

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/banner/ResumeBookBanner.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/banner/ResumeBookBanner.kt
@@ -35,6 +35,7 @@ import javafx.scene.layout.BackgroundSize
 import org.wycliffeassociates.otter.jvm.controls.skins.banner.ResumeBookBannerSkin
 import java.io.File
 import java.util.concurrent.Callable
+import javafx.geometry.Side
 
 class ResumeBookBanner : Control() {
 
@@ -72,13 +73,13 @@ class ResumeBookBanner : Control() {
             true,
             true,
             true,
-            true
+            false
         )
         return BackgroundImage(
             image,
             BackgroundRepeat.NO_REPEAT,
             BackgroundRepeat.NO_REPEAT,
-            BackgroundPosition.CENTER,
+            BackgroundPosition(Side.RIGHT, 0.0, false, Side.TOP, 0.0, false),
             backgroundSize
         )
     }

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/banner/WorkbookBanner.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/banner/WorkbookBanner.kt
@@ -36,6 +36,7 @@ import javafx.scene.layout.BackgroundSize
 import org.wycliffeassociates.otter.jvm.controls.skins.banner.WorkbookBannerSkin
 import java.io.File
 import java.util.concurrent.Callable
+import javafx.geometry.Side
 
 class WorkbookBanner : Control() {
 
@@ -72,14 +73,14 @@ class WorkbookBanner : Control() {
             1.0,
             true,
             true,
-            false,
-            true
+            true,
+            false
         )
         return BackgroundImage(
             image,
             BackgroundRepeat.NO_REPEAT,
             BackgroundRepeat.NO_REPEAT,
-            BackgroundPosition.DEFAULT,
+            BackgroundPosition(Side.RIGHT, 0.0, false, Side.TOP, 0.0, false),
             backgroundSize
         )
     }

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/ConfirmDialog.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/ConfirmDialog.kt
@@ -202,14 +202,14 @@ class ConfirmDialog : OtterDialog() {
             1.0,
             true,
             true,
-            false,
-            true
+            true,
+            false
         )
         return BackgroundImage(
             image,
             BackgroundRepeat.NO_REPEAT,
             BackgroundRepeat.NO_REPEAT,
-            BackgroundPosition.DEFAULT,
+            BackgroundPosition.CENTER,
             backgroundSize
         )
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/HomePage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/HomePage.kt
@@ -78,7 +78,7 @@ class HomePage : View() {
                             it?.let { workbook ->
                                 bookTitleProperty.set(workbook.target.title)
                                 backgroundImageFileProperty.set(
-                                    workbook.artworkAccessor.getArtwork(ImageRatio.FOUR_BY_ONE)
+                                    workbook.artworkAccessor.getArtwork(ImageRatio.TWO_BY_ONE)
                                 )
                                 sourceLanguageProperty.set(workbook.source.language.name)
                                 targetLanguageProperty.set(workbook.target.language.name)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookPageViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookPageViewModel.kt
@@ -160,7 +160,7 @@ class WorkbookPageViewModel : ViewModel() {
         val workbook = workbookDataStore.workbook
         return WorkbookBannerModel(
             title = workbook.target.title,
-            coverArt = workbook.artworkAccessor.getArtwork(ImageRatio.FOUR_BY_ONE),
+            coverArt = workbook.artworkAccessor.getArtwork(ImageRatio.TWO_BY_ONE),
             onDelete = { showDeleteDialogProperty.set(true) },
             onExport = {
                 val directory = chooseDirectory(FX.messages["exportProject"])


### PR DESCRIPTION
Improves image usage:

Banners now use the 2x1 aspect ration (4x1 doesn't crop well for our artwork) and align to the right of the banner.

Packages up a container to be used as the Bible Images Data Source in an s3 bucket, pulled down by gradle at build time, and installed with an initializer. 

Uses a zip file in the data source instead of a directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/353)
<!-- Reviewable:end -->
