### PR TITLE
Refactor css theme swapping

### DIFF
--- a/jvm/controls/build.gradle
+++ b/jvm/controls/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     implementation "org.kordamp.ikonli:ikonli-materialdesign-pack:$ikonliVer"
     implementation "org.kordamp.ikonli:ikonli-material-pack:$ikonliVer"
 
+    // Dark mode detector
+    implementation "com.github.Dansoftowner:jSystemThemeDetector:$systemThemeDectectorVer"
 
     // Atlassian commonmark (for rendering markdown)
     implementation "com.atlassian.commonmark:commonmark:$commonmarkVer"

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/OtterDialog.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/OtterDialog.kt
@@ -36,7 +36,7 @@ abstract class OtterDialog : Fragment() {
     private val roundRadius = 15.0
 
     private val osThemeDetector = OsThemeDetector.getDetector()
-    private val isOSDarkMode = SimpleBooleanProperty(osThemeDetector.isDark)
+    private val isOSDarkTheme = SimpleBooleanProperty(osThemeDetector.isDark)
 
     private val mainContainer = VBox().apply {
         addClass("otter-dialog-container")
@@ -106,7 +106,7 @@ abstract class OtterDialog : Fragment() {
     }
 
     private fun bindThemeToSystem() {
-        isOSDarkMode.onChange {
+        isOSDarkTheme.onChange {
             if (it) {
                 root.removeClass("light-theme")
                 root.addClass("dark-theme")
@@ -117,7 +117,7 @@ abstract class OtterDialog : Fragment() {
         }
 
         osThemeDetector.registerListener {
-            runLater { isOSDarkMode.set(it) }
+            runLater { isOSDarkTheme.set(it) }
         }
     }
 }

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/OtterDialog.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/OtterDialog.kt
@@ -55,6 +55,9 @@ abstract class OtterDialog : Fragment() {
 
     init {
         importStylesheet(resources.get("/css/otter-dialog.css"))
+        /* the dialog component does not derive from root view;
+         * it needs its own style class theme manipulation
+         */
         importStylesheet(resources["/css/theme/light-theme.css"])
         importStylesheet(resources["/css/theme/dark-theme.css"])
 

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/OtterDialog.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/OtterDialog.kt
@@ -18,6 +18,8 @@
  */
 package org.wycliffeassociates.otter.jvm.controls.dialog
 
+import com.jthemedetecor.OsThemeDetector
+import javafx.beans.property.SimpleBooleanProperty
 import javafx.geometry.Bounds
 import javafx.scene.layout.Priority
 import javafx.scene.layout.Region
@@ -33,6 +35,9 @@ abstract class OtterDialog : Fragment() {
 
     private val roundRadius = 15.0
 
+    private val osThemeDetector = OsThemeDetector.getDetector()
+    private val isOSDarkMode = SimpleBooleanProperty(osThemeDetector.isDark)
+
     private val mainContainer = VBox().apply {
         addClass("otter-dialog-container")
     }
@@ -40,10 +45,20 @@ abstract class OtterDialog : Fragment() {
     override val root = VBox().apply {
         addClass("otter-dialog-overlay")
         add(mainContainer)
+
+        if (osThemeDetector.isDark) {
+            addClass("dark-theme")
+        } else {
+            addClass("light-theme")
+        }
     }
 
     init {
         importStylesheet(resources.get("/css/otter-dialog.css"))
+        importStylesheet(resources["/css/theme/light-theme.css"])
+        importStylesheet(resources["/css/theme/dark-theme.css"])
+
+        bindThemeToSystem()
     }
 
     fun open() {
@@ -85,5 +100,21 @@ abstract class OtterDialog : Fragment() {
         rect.arcWidth = roundRadius
         rect.arcHeight = roundRadius
         region.clip = rect
+    }
+
+    private fun bindThemeToSystem() {
+        isOSDarkMode.onChange {
+            if (it) {
+                root.removeClass("light-theme")
+                root.addClass("dark-theme")
+            } else {
+                root.removeClass("dark-theme")
+                root.addClass("light-theme")
+            }
+        }
+
+        osThemeDetector.registerListener {
+            runLater { isOSDarkMode.set(it) }
+        }
     }
 }

--- a/jvm/controls/src/main/resources/css/theme/dark-theme.css
+++ b/jvm/controls/src/main/resources/css/theme/dark-theme.css
@@ -18,7 +18,7 @@
  */
  @import "/css/base-colors.css"
 
-* {
+.dark-theme {
     /*Primary Color */
     -wa-primary: #015AD9;
     -wa-primary-05: #015AD90D;
@@ -121,21 +121,21 @@
     -wa-dialog-background: -wa-background;
 }
 
-.workspace {
+.dark-theme .workspace {
     -fx-background-color: -wa-background;
 }
 
-.scroll-bar {
+.dark-theme .scroll-bar {
     -fx-background-color: #00000020;
 }
 
-.scroll-bar .thumb {
+.dark-theme .scroll-bar .thumb {
     -fx-background-color: #768198;
     -fx-background-insets: 0, 2, 0;
     -fx-background-radius: 0;
 }
 
-.scroll-bar .increment-button:hover,
-.scroll-bar .decrement-button:hover {
+.dark-theme .scroll-bar .increment-button:hover,
+.dark-theme .scroll-bar .decrement-button:hover {
     -fx-background-color: transparent;
 }

--- a/jvm/controls/src/main/resources/css/theme/light-theme.css
+++ b/jvm/controls/src/main/resources/css/theme/light-theme.css
@@ -18,7 +18,7 @@
  */
  @import "/css/base-colors.css"
 
-* {
+.light-theme {
     /*Primary Color */
     -wa-primary: #015AD9;
     -wa-primary-05: #015AD90D;
@@ -121,11 +121,11 @@
     -wa-dialog-background: -wa-background;
 }
 
-.workspace {
+.light-theme .workspace {
     -fx-background-color: -wa-background;
 }
 
-.scroll-bar .thumb {
+.light-theme .scroll-bar .thumb {
     -fx-background-color: #b3b3b3;
     -fx-background-insets: 0, 2, 0;
     -fx-background-radius: 0;

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RootView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RootView.kt
@@ -35,7 +35,7 @@ class RootView : View() {
 
     private val viewModel: RootViewModel by inject()
     private val osThemeDetector = OsThemeDetector.getDetector()
-    private val isOSDarkMode = SimpleBooleanProperty(osThemeDetector.isDark)
+    private val isOSDarkTheme = SimpleBooleanProperty(osThemeDetector.isDark)
 
     init {
         // Configure the Workspace: sets up the window menu and external app open events
@@ -81,7 +81,7 @@ class RootView : View() {
     }
 
     private fun bindAppThemeToSystem() {
-        isOSDarkMode.onChange {
+        isOSDarkTheme.onChange {
             if (it) {
                 root.removeClass("light-theme")
                 root.addClass("dark-theme")
@@ -92,7 +92,7 @@ class RootView : View() {
         }
 
         osThemeDetector.registerListener {
-            runLater { isOSDarkMode.set(it) }
+            runLater { isOSDarkTheme.set(it) }
         }
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RootView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RootView.kt
@@ -67,24 +67,27 @@ class RootView : View() {
             left<AppBar>()
             center<AppContent>()
         }
+
+        if (osThemeDetector.isDark) {
+            addClass("dark-theme")
+        } else {
+            addClass("light-theme")
+        }
     }
 
     private fun initThemeStylesheet() {
-        if (osThemeDetector.isDark) {
-            importStylesheet(resources["/css/root_dark.css"])
-        } else {
-            importStylesheet(resources["/css/root.css"])
-        }
+        importStylesheet(resources["/css/theme/light-theme.css"])
+        importStylesheet(resources["/css/theme/dark-theme.css"])
     }
 
     private fun bindAppThemeToSystem() {
         isOSDarkMode.onChange {
             if (it) {
-                FX.stylesheets.remove("/css/root.css")
-                FX.stylesheets.add("/css/root_dark.css")
+                root.removeClass("light-theme")
+                root.addClass("dark-theme")
             } else {
-                FX.stylesheets.remove("/css/root_dark.css")
-                FX.stylesheets.add("/css/root.css")
+                root.removeClass("dark-theme")
+                root.addClass("light-theme")
             }
         }
 


### PR DESCRIPTION
Previously, when the system's color preference changes, the css files for dark and light theme are replaced accordingly; this is not efficient. Now, it only needs to replace the css class name instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/418)
<!-- Reviewable:end -->
