### PR TITLE
Fix Marker Parsing

### DIFF
--- a/common/audio/build.gradle
+++ b/common/audio/build.gradle
@@ -1,5 +1,5 @@
 group = 'org.wycliffeassociates.otter.common'
-version = '0.3.1'
+version = '0.3.2'
 
 dependencies {
     testImplementation "junit:junit:$junitVer"

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/VerseMarkerChunk.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/VerseMarkerChunk.kt
@@ -44,14 +44,14 @@ class VerseMarkerChunk : CueChunk() {
     private fun separateOratureCues(allCues: List<AudioCue>) {
         val oratureRegex = Regex("^orature-vm-(\\d+)$")
         val loneDigitRegex = Regex("^\\d+$")
-        val numberRegex = Regex(".*(\\d+).*")
+        val numberRegex = Regex("(\\d+)")
 
         val oratureCues = allCues.filter { it.label.matches(oratureRegex) }
         val leftoverCues = allCues.filter { !oratureCues.contains(it) }
         val loneDigits = leftoverCues.filter { it.label.trim().matches(loneDigitRegex) }
         val potentialCues = leftoverCues
             .filter { !loneDigits.contains(it) }
-            .filter { it.label.matches(numberRegex) }
+            .filter { numberRegex.containsMatchIn(it.label) }
             .map {
                 val match = numberRegex.find(it.label)
                 val label = match!!.groupValues.first()!!

--- a/common/audio/src/test/kotlin/org/wycliffeassociates/otter/common/audio/wav/VerseMarkerChunkTest.kt
+++ b/common/audio/src/test/kotlin/org/wycliffeassociates/otter/common/audio/wav/VerseMarkerChunkTest.kt
@@ -166,6 +166,10 @@ class VerseMarkerChunkTest {
                 AudioCue(4112, "orature-vm-8"),
                 AudioCue(5112, "orature-vm-9"),
             )
+        ),
+        TestData(
+            listOf(AudioCue(10, "verse 10")),
+            listOf(AudioCue(10, "verse 10"), AudioCue(10, "orature-vm-10"))
         )
     )
 


### PR DESCRIPTION
Previous regex would only grab the last digit in markers with text (but not the orature-vm-# pattern).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/425)
<!-- Reviewable:end -->
