### PR TITLE
Bugfix: Allow Orature to work without Audio

### DIFF
--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/ConfigureAudioSystem.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/ConfigureAudioSystem.kt
@@ -87,12 +87,14 @@ class ConfigureAudioSystem @Inject constructor(
                 preferencesRepository.setOutputDevice(deviceName).blockingGet()
                 deviceName
             }
-            .map { deviceName -> deviceProvider.getOutputDevice(deviceName) }
-            .map { mixer ->
+            .map { deviceName ->
+                val mixer = deviceProvider.getOutputDevice(deviceName)
                 var line: SourceDataLine? = null
-                try {
-                    line = AudioSystem.getSourceDataLine(DEFAULT_AUDIO_FORMAT, mixer)
-                } catch (e: Exception) {
+                mixer?.let {
+                    try {
+                        line = AudioSystem.getSourceDataLine(DEFAULT_AUDIO_FORMAT, mixer)
+                    } catch (e: Exception) {
+                    }
                 }
                 if (line != null) Maybe.just(line) else Maybe.empty()
             }.flatMapMaybe { it }.blockingGet()
@@ -109,12 +111,14 @@ class ConfigureAudioSystem @Inject constructor(
                 preferencesRepository.setInputDevice(deviceName).blockingGet()
                 deviceName
             }
-            .map { deviceName -> deviceProvider.getInputDevice(deviceName) }
-            .map { mixer ->
+            .map { deviceName ->
+                val mixer = deviceProvider.getInputDevice(deviceName)
                 var line: TargetDataLine? = null
-                try {
-                    line = AudioSystem.getTargetDataLine(DEFAULT_AUDIO_FORMAT, mixer)
-                } catch (e: Exception) {
+                mixer?.let {
+                    try {
+                        line = AudioSystem.getTargetDataLine(DEFAULT_AUDIO_FORMAT, mixer)
+                    } catch (e: Exception) {
+                    }
                 }
                 if (line != null) Maybe.just(line) else Maybe.empty()
             }.flatMapMaybe { it }.blockingGet()

--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/ConfigureAudioSystem.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/ConfigureAudioSystem.kt
@@ -95,7 +95,6 @@ class ConfigureAudioSystem @Inject constructor(
                 } catch (e: Exception) {
                 }
                 if (line != null) Maybe.just(line) else Maybe.empty()
-                Maybe.empty<SourceDataLine>()
             }.flatMapMaybe { it }.blockingGet()
     }
 
@@ -118,7 +117,6 @@ class ConfigureAudioSystem @Inject constructor(
                 } catch (e: Exception) {
                 }
                 if (line != null) Maybe.just(line) else Maybe.empty()
-                Maybe.empty<TargetDataLine>()
             }.flatMapMaybe { it }.blockingGet()
     }
 }

--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioBufferPlayer.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioBufferPlayer.kt
@@ -31,7 +31,7 @@ import javax.sound.sampled.SourceDataLine
 import org.wycliffeassociates.otter.common.audio.AudioFile
 
 class AudioBufferPlayer(
-    private val player: SourceDataLine,
+    private val player: SourceDataLine?,
     private val errorRelay: PublishRelay<AudioError> = PublishRelay.create()
 ) : IAudioPlayer {
 
@@ -96,33 +96,35 @@ class AudioBufferPlayer(
 
     override fun play() {
         reader?.let { _reader ->
-            if (!player.isActive) {
-                listeners.forEach { it.onEvent(AudioPlayerEvent.PLAY) }
-                pause.set(false)
-                startPosition = _reader.framePosition
-                playbackThread = Thread {
-                    try {
-                        player.open()
-                        player.start()
-                        while (_reader.hasRemaining() && !pause.get() && !playbackThread.isInterrupted) {
-                            val written = _reader.getPcmBuffer(bytes)
-                            player.write(bytes, 0, written)
+            player?.let {
+                if (!player.isActive) {
+                    listeners.forEach { it.onEvent(AudioPlayerEvent.PLAY) }
+                    pause.set(false)
+                    startPosition = _reader.framePosition
+                    playbackThread = Thread {
+                        try {
+                            player.open()
+                            player.start()
+                            while (_reader.hasRemaining() && !pause.get() && !playbackThread.isInterrupted) {
+                                val written = _reader.getPcmBuffer(bytes)
+                                player.write(bytes, 0, written)
+                            }
+                            player.drain()
+                            if (!pause.get()) {
+                                startPosition = 0
+                                listeners.forEach { it.onEvent(AudioPlayerEvent.COMPLETE) }
+                                player.close()
+                                seek(0)
+                            }
+                        } catch (e: LineUnavailableException) {
+                            errorRelay.accept(AudioError(AudioErrorType.PLAYBACK, e))
+                        } catch (e: IllegalArgumentException) {
+                            errorRelay.accept(AudioError(AudioErrorType.PLAYBACK, e))
                         }
-                        player.drain()
-                        if (!pause.get()) {
-                            startPosition = 0
-                            listeners.forEach { it.onEvent(AudioPlayerEvent.COMPLETE) }
-                            player.close()
-                            seek(0)
-                        }
-                    } catch (e: LineUnavailableException) {
-                        errorRelay.accept(AudioError(AudioErrorType.PLAYBACK, e))
-                    } catch (e: IllegalArgumentException) {
-                        errorRelay.accept(AudioError(AudioErrorType.PLAYBACK, e))
-                    }
 
+                    }
+                    playbackThread.start()
                 }
-                playbackThread.start()
             }
         }
     }
@@ -132,9 +134,11 @@ class AudioBufferPlayer(
             val stoppedAt = getLocationInFrames()
             startPosition = stoppedAt
             pause.set(true)
-            player.stop()
-            player.flush()
-            player.close()
+            player?.let {
+                player.stop()
+                player.flush()
+                player.close()
+            }
             listeners.forEach { it.onEvent(AudioPlayerEvent.PAUSE) }
             _reader.seek(stoppedAt)
         }
@@ -159,12 +163,12 @@ class AudioBufferPlayer(
     }
 
     override fun seek(position: Int) {
-        val resume = player.isActive
-        player.stop()
+        val resume = player?.isActive ?: false
+        player?.stop()
         if (::playbackThread.isInitialized) {
             playbackThread.interrupt()
         }
-        player.flush()
+        player?.flush()
         startPosition = position
         reader?.seek(position)
         if (resume) {
@@ -173,7 +177,7 @@ class AudioBufferPlayer(
     }
 
     override fun isPlaying(): Boolean {
-        return player.isRunning
+        return player?.isRunning ?: false
     }
 
     override fun getDurationInFrames(): Int {
@@ -185,7 +189,7 @@ class AudioBufferPlayer(
     }
 
     override fun getLocationInFrames(): Int {
-        return startPosition + player.framePosition
+        return startPosition + (player?.framePosition ?: 0)
     }
 
     override fun getLocationMs(): Int {

--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioBufferPlayer.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioBufferPlayer.kt
@@ -76,6 +76,9 @@ class AudioBufferPlayer(
             _reader.open()
             _reader
         }
+        if (player == null) {
+            errorRelay.accept(AudioError(AudioErrorType.PLAYBACK, LineUnavailableException()))
+        }
     }
 
     override fun loadSection(file: File, frameStart: Int, frameEnd: Int) {
@@ -87,6 +90,9 @@ class AudioBufferPlayer(
             listeners.forEach { it.onEvent(AudioPlayerEvent.LOAD) }
             _reader.open()
             _reader
+        }
+        if (player == null) {
+            errorRelay.accept(AudioError(AudioErrorType.PLAYBACK, LineUnavailableException()))
         }
     }
 
@@ -125,7 +131,7 @@ class AudioBufferPlayer(
                     }
                     playbackThread.start()
                 }
-            }
+            } ?: errorRelay.accept(AudioError(AudioErrorType.PLAYBACK, LineUnavailableException()))
         }
     }
 

--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioConnectionFactory.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioConnectionFactory.kt
@@ -33,12 +33,12 @@ class AudioConnectionFactory(
     private val recorderConnectionFactory = AudioRecorderConnectionFactory(errorRelay)
 
     @Synchronized
-    fun setOutputLine(newLine: SourceDataLine) {
+    fun setOutputLine(newLine: SourceDataLine?) {
         playerConnectionFactory.setLine(newLine)
     }
 
     @Synchronized
-    fun setInputLine(newLine: TargetDataLine) {
+    fun setInputLine(newLine: TargetDataLine?) {
         recorderConnectionFactory.setLine(newLine)
     }
 

--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioPlayerConnectionFactory.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioPlayerConnectionFactory.kt
@@ -29,7 +29,7 @@ internal class AudioPlayerConnectionFactory(
     private val errorRelay: PublishRelay<AudioError> = PublishRelay.create()
 ) {
 
-    lateinit var outputLine: SourceDataLine
+    var outputLine: SourceDataLine? = null
 
     internal lateinit var player: AudioBufferPlayer
         private set
@@ -39,13 +39,13 @@ internal class AudioPlayerConnectionFactory(
     internal var currentConnection: AudioPlayerConnectionState? = null
 
     @Synchronized
-    fun setLine(newLine: SourceDataLine) {
+    fun setLine(newLine: SourceDataLine?) {
         if (this::player.isInitialized) {
             player.pause()
         } else {
             player = AudioBufferPlayer(newLine, errorRelay)
         }
-        newLine.close()
+        newLine?.close()
         outputLine = newLine
         currentConnection?.let {
             load(it)
@@ -99,7 +99,7 @@ internal class AudioPlayerConnectionFactory(
         try {
             player.pause()
             swapConnection(request)
-            outputLine.flush()
+            outputLine?.flush()
             if (request.id != currentConnection?.id) {
                 player.stop()
             }

--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioRecorder.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioRecorder.kt
@@ -30,7 +30,7 @@ import javax.sound.sampled.TargetDataLine
 private const val DEFAULT_BUFFER_SIZE = 1024
 
 class AudioRecorder(
-    val line: TargetDataLine,
+    val line: TargetDataLine?,
     private val errorRelay: PublishRelay<AudioError> = PublishRelay.create()
 ) : IAudioRecorder {
 
@@ -47,22 +47,24 @@ class AudioRecorder(
         .fromCallable {
             val byteArray = ByteArray(DEFAULT_BUFFER_SIZE)
             var totalRead = 0
-            while (true) {
-                if (line.isOpen || line.available() > 0) {
-                    totalRead += line.read(byteArray, 0, byteArray.size)
-                    audioByteObservable.onNext(byteArray)
-                } else {
-                    try {
-                        synchronized(monitor) {
-                            monitor.wait()
+            line?.let {
+                while (true) {
+                    if (line.isOpen || line.available() > 0) {
+                        totalRead += line.read(byteArray, 0, byteArray.size)
+                        audioByteObservable.onNext(byteArray)
+                    } else {
+                        try {
+                            synchronized(monitor) {
+                                monitor.wait()
+                            }
+                        } catch (e: InterruptedException) {
+                            stop()
                         }
-                    } catch (e: InterruptedException) {
-                        stop()
                     }
-                }
-                if (stop || pause) {
-                    line.close()
-                    if (stop) break
+                    if (stop || pause) {
+                        line.close()
+                        if (stop) break
+                    }
                 }
             }
             stop = false
@@ -74,8 +76,8 @@ class AudioRecorder(
     override fun start() {
         pause = false
         try {
-            line.open()
-            line.start()
+            line?.open()
+            line?.start()
         } catch (e: LineUnavailableException) {
             errorRelay.accept(AudioError(AudioErrorType.RECORDING, e))
         } catch (e: IllegalArgumentException) {
@@ -87,12 +89,12 @@ class AudioRecorder(
     }
 
     override fun pause() {
-        line.stop()
+        line?.stop()
         pause = true
     }
 
     override fun stop() {
-        line.stop()
+        line?.stop()
         stop = true
 
         // wakes up the recording thread to allow it to close

--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioRecorder.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioRecorder.kt
@@ -78,6 +78,9 @@ class AudioRecorder(
         try {
             line?.open()
             line?.start()
+            if (line == null) {
+                errorRelay.accept(AudioError(AudioErrorType.RECORDING, LineUnavailableException()))
+            }
         } catch (e: LineUnavailableException) {
             errorRelay.accept(AudioError(AudioErrorType.RECORDING, e))
         } catch (e: IllegalArgumentException) {

--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioRecorderConnectionFactory.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioRecorderConnectionFactory.kt
@@ -26,10 +26,10 @@ internal class AudioRecorderConnectionFactory(
     private val errorRelay: PublishRelay<AudioError> = PublishRelay.create()
 ) {
 
-    private lateinit var inputLine: TargetDataLine
+    private var inputLine: TargetDataLine? = null
 
     @Synchronized
-    fun setLine(newLine: TargetDataLine) {
+    fun setLine(newLine: TargetDataLine?) {
         inputLine = newLine
     }
 


### PR DESCRIPTION
Previously Orature would crash trying to configure the audio system if either an output or input device was missing. This will now allow null lines, and communicate the lack of a device via an error dialog when the user goes to play or record audio.