### PR TITLE
Fixed the bug with incorrect orientation in audioErrorDialog

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RootView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RootView.kt
@@ -112,7 +112,7 @@ class RootView : View() {
 
             backgroundImageProperty.set(resources.image("/images/audio_error.png"))
             cancelButtonTextProperty.set(messages["close"])
-            orientationProperty.set(settingsViewModel.orientationProperty.value)
+            orientationProperty.bind(settingsViewModel.orientationProperty)
 
             errorTypeProperty.bind(viewModel.audioErrorType)
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/429)
<!-- Reviewable:end -->
