### PR TITLE
Bugfix: setting bound text in delete dialog

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/WorkbookPage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/WorkbookPage.kt
@@ -272,16 +272,16 @@ class WorkbookPage : View() {
                             }
                         }
                     )
-                    messageTextProperty.bind(
-                        viewModel.activeProjectTitleProperty.stringBinding {
-                            it?.let {
-                                MessageFormat.format(
-                                    messages["exportProjectMessage"],
-                                    it
-                                )
-                            }
+
+                    viewModel.activeProjectTitleProperty.stringBinding {
+                        it?.let {
+                            MessageFormat.format(
+                                messages["exportProjectMessage"],
+                                it
+                            )
                         }
-                    )
+                    }.onChangeAndDoNow { messageTextProperty.set(it) }
+                    
                     backgroundImageFileProperty.bind(viewModel.activeProjectCoverProperty)
                     open()
                 } else {


### PR DESCRIPTION
App crashes if you export a project and then delete it, due to the messageTextProperty here being bound.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/431)
<!-- Reviewable:end -->
