### PR TITLE
Bugfix: Hide target audio for verses

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/plugin/AudioPlugin.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/plugin/AudioPlugin.kt
@@ -133,7 +133,7 @@ class AudioPlugin(
                     "--source_chunk_end=${pluginParameters.sourceChunkEnd}",
                     "--source_text=${pluginParameters.sourceText}",
                     "--action_title=${pluginParameters.actionText}",
-                    "--target_chapter_audio=${pluginParameters.targetChapterAudio?.absolutePath}",
+                    (if (pluginParameters.chunkNumber == null) "--target_chapter_audio=${pluginParameters.targetChapterAudio?.absolutePath}" else ""),
                     "--content_title=${
                         MessageFormat.format(
                             FX.messages["bookChapterTitle"],


### PR DESCRIPTION
The target audio is of the entire chapter. This should be available for Chapters, but not for Verses and Chunks.

This change only passes in target audio if there is not a chunk number set (chapter only).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/440)
<!-- Reviewable:end -->
