### PR TITLE
Bugfix: Seek to next/previous with verse bridges

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordScriptureViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordScriptureViewModel.kt
@@ -239,9 +239,8 @@ class RecordScriptureViewModel : ViewModel() {
             StepDirection.FORWARD -> 1
             StepDirection.BACKWARD -> -1
         }
-        chunkList
-            .find { it.start == activeChunk.start + amount }
-            ?.let { newChunk -> activeChunkProperty.set(newChunk) }
+        val nextIndex = chunkList.indexOf(activeChunk) + amount
+        chunkList.elementAtOrNull(nextIndex)?.let { activeChunkProperty.set(it) }
     }
 
     fun recordNewTake() {


### PR DESCRIPTION
Instead of trying to find a verse number matching the starting verse +/- 1, get the element at the next or previous list index.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/443)
<!-- Reviewable:end -->
