### PR TITLE
Restore code after playback loop

### DIFF
--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/controllers/AudioPlayerController.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/controllers/AudioPlayerController.kt
@@ -99,10 +99,6 @@ class AudioPlayerController(
                             startAtLocation = 0
                             player.getAudioReader()?.seek(0)
                         }
-                        AudioPlayerEvent.STOP -> {
-                            audioSlider.value = 0.0
-                            startAtLocation = 0
-                        }
                     }
                 }
             }

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/media/SimpleAudioPlayer.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/media/SimpleAudioPlayer.kt
@@ -45,6 +45,7 @@ import org.wycliffeassociates.otter.jvm.controls.controllers.AudioPlayerControll
 import org.wycliffeassociates.otter.jvm.controls.controllers.framesToTimecode
 import tornadofx.*
 import java.text.MessageFormat
+import org.wycliffeassociates.otter.common.audio.DEFAULT_SAMPLE_RATE
 
 class SimpleAudioPlayer(
     player: IAudioPlayer? = null
@@ -77,7 +78,7 @@ class SimpleAudioPlayer(
         nodeOrientation = NodeOrientation.LEFT_TO_RIGHT
 
         playerProperty.onChange {
-            audioSampleRate.set(it?.getAudioReader()?.sampleRate ?: 0)
+            audioSampleRate.set(it?.getAudioReader()?.sampleRate ?: DEFAULT_SAMPLE_RATE)
         }
 
         alignment = Pos.CENTER

--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioBufferPlayer.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioBufferPlayer.kt
@@ -125,6 +125,13 @@ class AudioBufferPlayer(
                                     player.write(output, 0, output.size)
                                 }
                             }
+                            player.drain()
+                            if (!pause.get()) {
+                                startPosition = 0
+                                listeners.forEach { it.onEvent(AudioPlayerEvent.COMPLETE) }
+                                player.close()
+                                seek(0)
+                            }
                         } catch (e: LineUnavailableException) {
                             errorRelay.accept(AudioError(AudioErrorType.PLAYBACK, e))
                         } catch (e: IllegalArgumentException) {


### PR DESCRIPTION
https://github.com/Bible-Translation-Tools/Orature/commit/e6d57a9e01c3ea8b930625cd390ea8515db010a0#diff-c03c38aa3a4e057d37d3e475899a9f723f784f97be36cd44493bb55202c77524

The commit above did not retain the block of code submitting a complete event and resetting the seek/start position, causing the slider to never "finish"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/455)
<!-- Reviewable:end -->
